### PR TITLE
HC-446: Added support for authentication in Otello

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can intialize it 1 of 2 ways
 * importing the `otello` library
     * `import otello` and `otello.initialize()`
 
-It will prompt the user to enter the HySDS host and parameters for authentication (will be implemented in the future)
+It will prompt the user to enter the HySDS host and parameters for authentication
 ```bash
 $ otello init
 HySDS host (current value: https://###.##.###.###/):
@@ -34,7 +34,14 @@ host: https://###.##.###.###/
 username: ########
 ```
 
-
+For authentication to work properly, AWS Secrets Manager should be set up prior to initializing
+otello with authentication. When cluster authentication is set to `y`, it will then ask for
+the Secrets Manager ID, which is the ID associated with the stored Secret in Secrets Manager.
+If the ID is not specified in the config file, it defaults to the username that was set:
+```bash
+HySDS cluster authenticated (y/n): y
+AWS Secrets Manager ID (current value: ########): 
+```
 
 ## Continuous Integration (CI)
 HySDS uses Jenkins to run continuous integration (CI)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ host: https://###.##.###.###/
 username: ########
 ```
 
-For authentication to work properly, AWS Secrets Manager should be set up prior to initializing
+For authentication to work properly, [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html) should be set up prior to initializing
 otello with authentication. When cluster authentication is set to `y`, it will then ask for
 the Secrets Manager ID, which is the ID associated with the stored Secret in Secrets Manager.
 If the ID is not specified in the config file, it defaults to the username that was set:

--- a/otello/base.py
+++ b/otello/base.py
@@ -22,8 +22,11 @@ class Base:
             raise Exception(e)
 
         self._session = requests.Session()
-        if "pass" in self._cfg:
-            self._session.headers.update({"Authorization", f"Basic {self._cfg['pass']}"})
+        if self._cfg["auth"] is True:
+            if "token" in self._cfg:
+                self._session.headers.update({"Authorization", f"Basic {self._cfg['token']}"})
+            else:
+                raise Exception(f"Missing 'token' field in configuration file: {self._cfg}")
         else:
             self._session.verify = False
 

--- a/otello/base.py
+++ b/otello/base.py
@@ -7,7 +7,7 @@ import json
 
 
 class Base:
-    def __init__(self, cfg=None):
+    def __init__(self, cfg=None, session=None):
         if cfg is None:
             cfg_dir = os.path.join(str(Path.home()), '.config/otello')
             cfg = os.path.join(cfg_dir, 'config.yml')
@@ -23,22 +23,25 @@ class Base:
         except Exception as e:
             raise Exception(e)
 
-        self._session = requests.Session()
-        if self._cfg["auth"] is True:
-            try:
-                client = boto3.client("secretsmanager")
-                response = client.get_secret_value(
-                    SecretId=self._cfg["aws_secret_id"]
-                )
-                secret_string = json.loads(response["SecretString"])
-                self._session.auth = (self._cfg["username"],
-                                      secret_string[self._cfg["username"]]
-                                      )
-            except Exception as e:
-                raise Exception(f"Error occurred while trying to set "
-                                f"authentication using AWS Secrets "
-                                f"Manager:\n{str(e)}")
-        self._session.verify = False
+        if session:
+            self._session = session
+        else:
+            self._session = requests.Session()
+            if self._cfg["auth"] is True:
+                try:
+                    client = boto3.client("secretsmanager")
+                    response = client.get_secret_value(
+                        SecretId=self._cfg["aws_secret_id"]
+                    )
+                    secret_string = json.loads(response["SecretString"])
+                    self._session.auth = (self._cfg["username"],
+                                          secret_string[self._cfg["username"]]
+                                          )
+                except Exception as e:
+                    raise Exception(f"Error occurred while trying to set "
+                                    f"authentication using AWS Secrets "
+                                    f"Manager:\n{str(e)}")
+            self._session.verify = False
 
     def get_cfg(self):
         return self._cfg

--- a/otello/base.py
+++ b/otello/base.py
@@ -24,7 +24,7 @@ class Base:
         self._session = requests.Session()
         if self._cfg["auth"] is True:
             if "token" in self._cfg:
-                self._session.headers.update({"Authorization", f"Basic {self._cfg['token']}"})
+                self._session.headers.update({"Authorization": f"Basic {self._cfg['token']}"})
             else:
                 raise Exception(f"Missing 'token' field in configuration file: {self._cfg}")
         else:

--- a/otello/base.py
+++ b/otello/base.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import yaml
+import requests
 
 
 class Base:
@@ -19,6 +20,12 @@ class Base:
             raise yaml.YAMLError(e)
         except Exception as e:
             raise Exception(e)
+
+        self._session = requests.Session()
+        if "pass" in self._cfg:
+            self._session.headers.update({"Authorization", f"Basic {self._cfg['pass']}"})
+        else:
+            self._session.verify = False
 
     def get_cfg(self):
         return self._cfg

--- a/otello/base.py
+++ b/otello/base.py
@@ -27,8 +27,7 @@ class Base:
                 self._session.headers.update({"Authorization": f"Basic {self._cfg['token']}"})
             else:
                 raise Exception(f"Missing 'token' field in configuration file: {self._cfg}")
-        else:
-            self._session.verify = False
+        self._session.verify = False
 
     def get_cfg(self):
         return self._cfg

--- a/otello/ci.py
+++ b/otello/ci.py
@@ -1,5 +1,4 @@
 import os
-import requests
 
 # from otello.utils import decorator
 from otello.base import Base
@@ -32,7 +31,7 @@ class CI(Base):
         }
         if self.branch:
             data['branch'] = self.branch
-        req = requests.get(endpoint, params=data, verify=False)
+        req = self._session.get(endpoint, params=data)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -51,7 +50,7 @@ class CI(Base):
         }
         if self.branch:
             data['branch'] = self.branch
-        req = requests.post(endpoint, data=data, verify=False)
+        req = self._session.post(endpoint, data=data)
         if req.status_code != 200:
             raise Exception(req.text)
         print(req.text)
@@ -69,7 +68,7 @@ class CI(Base):
         }
         if self.branch:
             payload['branch'] = self.branch
-        req = requests.delete(endpoint, params=payload, verify=False)
+        req = self._session.delete(endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         return req.json()
@@ -87,7 +86,7 @@ class CI(Base):
         }
         if self.branch:
             data['branch'] = self.branch
-        req = requests.post(endpoint, data=data, verify=False)
+        req = self._session.post(endpoint, data=data)
         if req.status_code != 200:
             raise Exception(req.text)
         return req.json()
@@ -109,7 +108,7 @@ class CI(Base):
         if build_number is not None:
             payload['build_number'] = build_number
 
-        req = requests.get(endpoint, params=payload, verify=False)
+        req = self._session.get(endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         return req.json()
@@ -127,7 +126,7 @@ class CI(Base):
         }
         if self.branch:
             payload['branch'] = self.branch
-        req = requests.delete(endpoint, params=payload, verify=False)
+        req = self._session.delete(endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         return req.json()
@@ -148,7 +147,7 @@ class CI(Base):
         if build_number is not None:
             payload['build_number'] = build_number
 
-        req = requests.delete(endpoint, params=payload, verify=False)
+        req = self._session.delete(endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         return req.json()

--- a/otello/client.py
+++ b/otello/client.py
@@ -61,12 +61,13 @@ def initialize():
         # Using AWS Secrets Manager for authentication
         # Current assumption is that the Secret ID will be equal to the username.
         # If not, end user will change it.
-        user_prompt = 'AWS Secrets Manager ID (current value: %s): ' % config['username']
+        existing_secret_id = config.get('aws_secret_id', config["username"])
+        user_prompt = f"AWS Secrets Manager ID (current value: {existing_secret_id}): "
         secret_id = input(user_prompt)
         if secret_id:
             config['aws_secret_id'] = secret_id
         else:
-            config['aws_secret_id'] = config['username']
+            config['aws_secret_id'] = existing_secret_id
     else:
         config['auth'] = False
 

--- a/otello/client.py
+++ b/otello/client.py
@@ -60,7 +60,9 @@ def initialize():
         config['auth'] = True
 
         # Password
-        config['pass'] = getpass.getpass()
+        password = getpass.getpass()
+        token = b64encode(f"{username}:{password}".encode('utf-8')).decode("ascii")
+        config['token'] = token
     else:
         config['auth'] = False
 

--- a/otello/client.py
+++ b/otello/client.py
@@ -60,8 +60,7 @@ def initialize():
         config['auth'] = True
 
         # Password
-        password = getpass.getpass()
-        # TODO: use username + password to retrieve access_token and refresh_token from SSO provider
+        config['pass'] = getpass.getpass()
     else:
         config['auth'] = False
 

--- a/otello/client.py
+++ b/otello/client.py
@@ -2,6 +2,7 @@ import os
 import yaml
 import getpass
 from pathlib import Path
+from base64 import b64encode
 
 
 def initialize():

--- a/otello/client.py
+++ b/otello/client.py
@@ -1,8 +1,7 @@
 import os
 import yaml
-import getpass
+
 from pathlib import Path
-from base64 import b64encode
 
 
 def initialize():
@@ -59,11 +58,15 @@ def initialize():
     is_auth = input('HySDS cluster authenticated (y/n): ')
     if is_auth.lower() == 'y':
         config['auth'] = True
-
-        # Password
-        password = getpass.getpass()
-        token = b64encode(f"{username}:{password}".encode('utf-8')).decode("ascii")
-        config['token'] = token
+        # Using AWS Secrets Manager for authentication
+        # Current assumption is that the Secret ID will be equal to the username.
+        # If not, end user will change it.
+        user_prompt = 'AWS Secrets Manager ID (current value: %s): ' % config['username']
+        secret_id = input(user_prompt)
+        if secret_id:
+            config['aws_secret_id'] = secret_id
+        else:
+            config['aws_secret_id'] = config['username']
     else:
         config['auth'] = False
 

--- a/otello/mozart.py
+++ b/otello/mozart.py
@@ -37,7 +37,7 @@ class Mozart(Base):
         host = self._cfg['host']
         endpoint = os.path.join(host, 'grq/api/v0.1/grq/on-demand')
 
-        req = requests.get(endpoint)
+        req = self._session.get(endpoint)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()

--- a/otello/mozart.py
+++ b/otello/mozart.py
@@ -3,7 +3,6 @@ import ast
 import json
 from datetime import datetime, date
 import time
-import requests
 
 from otello.base import Base
 from otello.utils import generate_tags
@@ -38,7 +37,7 @@ class Mozart(Base):
         host = self._cfg['host']
         endpoint = os.path.join(host, 'grq/api/v0.1/grq/on-demand')
 
-        req = requests.get(endpoint, verify=False)
+        req = requests.get(endpoint)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -61,7 +60,7 @@ class Mozart(Base):
         endpoint = os.path.join(host, 'grq/api/v0.1/grq/on-demand')
 
         payload = {'id': job}
-        req = requests.get(endpoint, params=payload, verify=False)
+        req = self._session.get(endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -123,7 +122,7 @@ class Mozart(Base):
         while True:
             params['page_size'] = page_size
             params['offset'] = offset
-            req = requests.get(endpoint, params=params, verify=False)
+            req = self._session.get(endpoint, params=params)
             if req.status_code != 200:
                 raise Exception(req.text)
             res = req.json()
@@ -215,7 +214,7 @@ class JobType(Base):
         job_endpoint = os.path.join(host, 'grq/api/v0.1/hysds_io/type')
 
         payload = {'id': self.hysds_io}
-        req = requests.get(job_endpoint, params=payload, verify=False)
+        req = self._session.get(job_endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -248,7 +247,7 @@ class JobType(Base):
         host = self._cfg['host']
         queue_endpoint = os.path.join(host, 'mozart/api/v0.1/queue/list')
         payload = {'id': self.job_spec}
-        req = requests.get(queue_endpoint, params=payload, verify=False)
+        req = self._session.get(queue_endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -492,7 +491,7 @@ class JobType(Base):
         }
         host = self._cfg['host']
         endpoint = os.path.join(host, 'mozart/api/v0.1/job/submit')
-        req = requests.post(endpoint, data=job_payload, verify=False)
+        req = self._session.post(endpoint, data=job_payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -549,7 +548,7 @@ class Job(Base):
         host = self._cfg['host']
         endpoint = os.path.join(host, 'mozart/api/v0.1/job/status')
         payload = {'id': self.job_id}
-        req = requests.get(endpoint, params=payload, verify=False)
+        req = self._session.get(endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -564,7 +563,7 @@ class Job(Base):
         endpoint = os.path.join(host, 'mozart/api/v0.1/job/info')
 
         payload = {'id': self.job_id}
-        req = requests.get(endpoint, params=payload, verify=False)
+        req = self._session.get(endpoint, params=payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -628,7 +627,7 @@ class Job(Base):
 
         host = self._cfg['host']
         endpoint = os.path.join(host, 'mozart/api/v0.1/job/submit')
-        req = requests.post(endpoint, data=job_payload, verify=False)
+        req = self._session.post(endpoint, data=job_payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -676,7 +675,7 @@ class Job(Base):
 
         host = self._cfg['host']
         endpoint = os.path.join(host, 'mozart/api/v0.1/job/submit')
-        req = requests.post(endpoint, data=job_payload, verify=False)
+        req = self._session.post(endpoint, data=job_payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -718,7 +717,7 @@ class Job(Base):
 
         host = self._cfg['host']
         endpoint = os.path.join(host, 'mozart/api/v0.1/job/submit')
-        req = requests.post(endpoint, data=job_payload, verify=False)
+        req = self._session.post(endpoint, data=job_payload)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()
@@ -733,7 +732,7 @@ class Job(Base):
         """
         host = self._cfg['host']
         endpoint = os.path.join(host, 'mozart/api/v0.1/job/products/%s' % self.job_id)
-        req = requests.get(endpoint, verify=False)
+        req = self._session.get(endpoint)
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()

--- a/otello/mozart.py
+++ b/otello/mozart.py
@@ -48,7 +48,7 @@ class Mozart(Base):
             hysds_io = j['hysds_io']
             job_spec = j['job_spec']
             label = j.get('label')
-            jobs[job_spec] = JobType(hysds_io=hysds_io, job_spec=job_spec, label=label)
+            jobs[job_spec] = JobType(hysds_io=hysds_io, job_spec=job_spec, label=label, session=self._session)
         return jobs
 
     def get_job_type(self, job):
@@ -70,7 +70,7 @@ class Mozart(Base):
         job_spec = job_type['job_spec']
         label = job_type.get('label')
 
-        return JobType(hysds_io=hysds_io, job_spec=job_spec, label=label)
+        return JobType(hysds_io=hysds_io, job_spec=job_spec, label=label, session=self._session)
 
     def get_jobs(self, tag=None, job_type=None, queue=None, priority=None, status=None, start_time=None, end_time=None):
         """
@@ -117,7 +117,7 @@ class Mozart(Base):
                 end_time = end_time.isoformat()
             params['end_time'] = end_time
 
-        js = JobSet()
+        js = JobSet(session=self._session)
         page_size, offset = 100, 0
         while True:
             params['page_size'] = page_size
@@ -131,7 +131,7 @@ class Mozart(Base):
             for job in res['result']:
                 _id = job['id']
                 tags = job['tags']
-                js.append(Job(_id, tags))
+                js.append(Job(_id, tags, session=self._session))
             offset += 100
         return js
 
@@ -171,12 +171,12 @@ class JobType(Base):
         submit_job: submit Job to HySDS, returns a Job class object
     """
 
-    def __init__(self, hysds_io=None, job_spec=None, label=None, cfg=None):
+    def __init__(self, hysds_io=None, job_spec=None, label=None, cfg=None, session=None):
         """
         :param hysds_io: (str) hysds_ios ID
         :param job_spec: (str) job-specification
         """
-        super().__init__(cfg=cfg)
+        super().__init__(cfg=cfg, session=session)
 
         if hysds_io is None or job_spec is None:
             raise Exception("both hysds_io and job_spec must be supplied")
@@ -515,11 +515,11 @@ class Job(Base):
     PURGE_JOB_NAME = 'job-lw-mozart-purge'
     RETRY_JOB_NAME = 'job-lw-mozart-retry'
 
-    def __init__(self, job_id=None, tags=None, cfg=None):
+    def __init__(self, job_id=None, tags=None, cfg=None, session=None):
         """
         :param job_id: str, job UUID
         """
-        super().__init__(cfg=cfg)
+        super().__init__(cfg=cfg, session=session)
         self.job_id = job_id
         if tags is not None:
             if type(tags) == str:
@@ -765,11 +765,11 @@ class JobSet(Base):
         wait_for_completion: wait for all "completion" of jobs
     """
 
-    def __init__(self, job_set=None, cfg=None):
+    def __init__(self, job_set=None, cfg=None, session=None):
         """
         :param job_set: list[Job], list of Job(s)
         """
-        super().__init__(cfg=cfg)
+        super().__init__(cfg=cfg, session=session)
 
         if job_set is None:
             self.job_set = []

--- a/otello/mozart.py
+++ b/otello/mozart.py
@@ -36,8 +36,8 @@ class Mozart(Base):
         """
         host = self._cfg['host']
         endpoint = os.path.join(host, 'grq/api/v0.1/grq/on-demand')
-
         req = self._session.get(endpoint)
+
         if req.status_code != 200:
             raise Exception(req.text)
         res = req.json()

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(
         'pyyaml',
         'urllib3',
         'requests',
+        'boto3'
     ]
 )


### PR DESCRIPTION
This PR updates Otello such that it now supports authentication so that end users wishing to use Otello outside of a cluster environment can do so. Authentication is done by using AWS' Secrets Manager feature, where the username and password information are stored.

When initializing Otello to use authentication, it will prompt you to enter an AWS Secrets Manager ID, which is the ID of the Secret that stores the username and password information that has access to a HySDS cluster. The `base` class was updated such that when the object is initialized, it will create a requests `Session` object and if authentication is set, it will go out to SecretsManager and set the Basic Authentication in the `Session` object. Furthermore, the `base` class initializer method was updated such that you can optionally pass in a `session` object in order to persist a single session throughout a program execution rather than creating a new one for each base class initialization.  