### PR TITLE
HC-580: Update wait_for_completion function to allow complete statuses to be customizable

### DIFF
--- a/otello/mozart.py
+++ b/otello/mozart.py
@@ -779,17 +779,23 @@ class Job(Base):
         res = req.json()
         return res['results']
 
-    def wait_for_completion(self):
+    def wait_for_completion(self, complete_statuses=None):
         """
         will loop (with 30 second delay) until the job compeltes (or fails)
         :return: str: job status when job completed (or fails)
         """
+        statuses = ['job-failed', 'job-deduped', 'job-completed', 'job-offline']
+        if complete_statuses:
+            if isinstance(complete_statuses, str):
+                statuses = [complete_statuses]
+            else:
+                statuses = complete_statuses
         time.sleep(3)
         while True:
             try:
                 status = self.get_status()
                 print(f"{self}: {status} {datetime.now(timezone.utc).replace(tzinfo=None).isoformat()}")
-                if status in ('job-failed', 'job-deduped', 'job-completed', 'job-offline'):
+                if status in statuses:
                     return status
             except Exception as e:
                 print(e)


### PR DESCRIPTION
This PR updates the existing `wait_for_completion` function such that we can pass in a custom set of complete statuses. A use-case for this is if the caller wishes to not include `job-offline` as a completion status.

In terms of testing, updated the calling function to not include `job-offline` and verified that the `wait_for_completion` still polls:

<img width="1976" height="449" alt="image" src="https://github.com/user-attachments/assets/75322120-4bc7-484f-b158-11592efd4b98" />
